### PR TITLE
ドキュメントのリンク修正

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,37 +3,45 @@
 ## ドキュメント構成
 
 ### 📐 アーキテクチャ
-- [システム概要](/architecture/system-overview.md)
-- [設計判断](/architecture/design-decisions.md)
-- [コンポーネント設計](/architecture/components/)
+
+- [システム概要](./architecture/system-overview.md)
+- [設計判断](./architecture/design-decisions.md)
+- [コンポーネント設計](./architecture/components/)
 
 ### 📊 進捗管理
-- [進捗報告](/progress/)
+
+- [進捗報告](./progress/)
   - 日次の詳細な進捗
   - 週次サマリー
   - 月次レポート
 
 ### 🔧 課題管理
-- [アクティブな課題](/issues/active/)
-- [解決済みの課題](/issues/resolved/)
+
+- [アクティブな課題](./issues/active/)
+- [解決済みの課題](./issues/resolved/)
 
 ### 📘 ガイド
-- [デプロイメントガイド](/guides/deployment.md)
-- [GCPセットアップガイド](/guides/gcp-setup.md)
+
+- [デプロイメントガイド](./guides/deployment.md)
+- [GCPセットアップガイド](./guides/gcp-setup.md)
 
 ### 🔗 外部連携
-- [AppSheet連携](/integrations/appsheet-integration.md)
-- [Google Drive連携](/integrations/google-drive.md)
+
+- [AppSheet連携](./integrations/appsheet-integration.md)
+- [Google Drive連携](./integrations/google-drive.md)
 
 ### 🛠 運用・保守
-- [トラブルシューティング](/maintenance/troubleshooting.md)
+
+- [トラブルシューティング](./maintenance/troubleshooting.md)
 
 ## ドキュメント更新ガイドライン
+
 1. 各ドキュメントは適切なディレクトリに配置
 2. 更新時は必ず日付を記録
 3. 大きな変更は週次サマリーに記載
 4. 古くなった情報は適宜アーカイブ
 
 ## 関連リンク
+
 - [プロジェクトリポジトリ](https://github.com/yasushi-honda/HTMLtoPDF-Engine)
 - [課題管理ボード](https://github.com/yasushi-honda/HTMLtoPDF-Engine/projects)


### PR DESCRIPTION
ドキュメントのパスが絶対パスになっていました。これはGithub上では確認できなくなります。

## Sourcery によるサマリー

バグ修正:
- ドキュメント内の壊れたリンクを、絶対パスから相対パスに更新することで修正します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes broken links in the documentation by updating absolute paths to relative paths.

</details>